### PR TITLE
Feature: Add Jack support

### DIFF
--- a/mod/lib/mod.lua
+++ b/mod/lib/mod.lua
@@ -7,10 +7,12 @@ mod.hook.register("system_post_startup", "ndi-system-post-startup", function()
   ndi_mod = require 'ndi_mod'
 
   ndi_mod.init()
+  ndi_mod.init_audio()
   ndi_mod.start()
 end)
 
 mod.hook.register("system_pre_shutdown", "ndi-system-pre-shutdown", function()
+  ndi_mod.cleanup_audio()
   ndi_mod.cleanup()
 end)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,8 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
 
 include(FindPkgConfig)
 pkg_check_modules(LIBLUA REQUIRED lua-5.3)
-include_directories(${LIBLUA_INCLUDE_DIRS})
+pkg_check_modules(JACK REQUIRED jack)
+include_directories(${LIBLUA_INCLUDE_DIRS} ${JACK_INCLUDE_DIRS})
 
 #
 # module
@@ -35,9 +36,11 @@ target_include_directories(lua-extension PUBLIC
 
 target_link_directories(lua-extension PUBLIC
   "${NDI_SDK_PATH}/lib"
+  ${JACK_LIBRARY_DIRS}
 )
 
 target_link_libraries(lua-extension PUBLIC
   ndi
+  ${JACK_LIBRARIES}
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ include_directories(${LIBLUA_INCLUDE_DIRS} ${JACK_INCLUDE_DIRS})
 #
 set(SOURCE_FILES
   ndi_mod.cpp
+  ndi_mod_audio.cpp
 )
 
 add_library(lua-extension MODULE ${SOURCE_FILES})

--- a/src/ndi_mod.cpp
+++ b/src/ndi_mod.cpp
@@ -2,6 +2,9 @@
 
 #include <iostream>
 #include <map>
+#include <cstring>
+
+#include <jack/jack.h>
 
 // lua
 #include <lauxlib.h>
@@ -27,6 +30,16 @@ NDIlib_video_frame_v2_t ndi_norns_frame;
 static bool running = false;
 static bool initialized = false;
 static bool failed = false;
+
+// jack audio
+static const int NDI_JACK_MAX_FRAMES = 8192;
+static const int NDI_JACK_NUM_CHANNELS = 2;
+static jack_client_t* jack_client = NULL;
+static jack_port_t* jack_port_left = NULL;
+static jack_port_t* jack_port_right = NULL;
+static float jack_audio_buffer[NDI_JACK_NUM_CHANNELS * NDI_JACK_MAX_FRAMES];
+static NDIlib_send_instance_t ndi_audio_sender = NULL;
+static NDIlib_audio_frame_v2_t ndi_audio_frame;
 
 //
 // core functions
@@ -75,6 +88,113 @@ int destroy_sender(cairo_surface_t* surface) {
     return 0;
 }
 
+//
+// jack audio functions
+//
+
+static int jack_process_callback(jack_nframes_t nframes, void* arg) {
+    if (!running || !ndi_audio_sender || nframes > NDI_JACK_MAX_FRAMES)
+        return 0;
+
+    float* left = (float*)jack_port_get_buffer(jack_port_left, nframes);
+    float* right = (float*)jack_port_get_buffer(jack_port_right, nframes);
+
+    // copy into planar buffer: channel 0 then channel 1
+    memcpy(jack_audio_buffer, left, nframes * sizeof(float));
+    memcpy(jack_audio_buffer + nframes, right, nframes * sizeof(float));
+
+    ndi_audio_frame.no_samples = nframes;
+    ndi_audio_frame.channel_stride_in_bytes = nframes * sizeof(float);
+    NDIlib_send_send_audio_v2(ndi_audio_sender, &ndi_audio_frame);
+
+    return 0;
+}
+
+static void jack_shutdown_callback(void* arg) {
+    MSG("JACK server shut down unexpectedly");
+    jack_client = NULL;
+    jack_port_left = NULL;
+    jack_port_right = NULL;
+    ndi_audio_sender = NULL;
+}
+
+static void initialize_jack() {
+    jack_status_t status;
+    jack_client = jack_client_open("ndi-mod", JackNoStartServer, &status);
+    if (!jack_client) {
+        MSG("JACK: could not open client (server not running?), continuing without audio");
+        return;
+    }
+
+    jack_port_left = jack_port_register(jack_client, "input_1",
+        JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+    jack_port_right = jack_port_register(jack_client, "input_2",
+        JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+
+    if (!jack_port_left || !jack_port_right) {
+        MSG("JACK: failed to register ports, continuing without audio");
+        jack_client_close(jack_client);
+        jack_client = NULL;
+        jack_port_left = NULL;
+        jack_port_right = NULL;
+        return;
+    }
+
+    // cache the "screen" sender for audio
+    cairo_t* ctx = (cairo_t*)screen_context_get_primary();
+    if (ctx) {
+        cairo_surface_t* surface = cairo_get_target(ctx);
+        auto it = surface_sender_map.find(surface);
+        if (it != surface_sender_map.end()) {
+            ndi_audio_sender = it->second;
+        }
+    }
+
+    // pre-fill audio frame descriptor
+    memset(&ndi_audio_frame, 0, sizeof(ndi_audio_frame));
+    ndi_audio_frame.timecode = NDIlib_send_timecode_synthesize;
+    ndi_audio_frame.sample_rate = jack_get_sample_rate(jack_client);
+    ndi_audio_frame.no_channels = NDI_JACK_NUM_CHANNELS;
+    ndi_audio_frame.no_samples = 0;
+    ndi_audio_frame.p_data = jack_audio_buffer;
+    ndi_audio_frame.channel_stride_in_bytes = 0;
+
+    jack_set_process_callback(jack_client, jack_process_callback, NULL);
+    jack_on_shutdown(jack_client, jack_shutdown_callback, NULL);
+
+    if (jack_activate(jack_client)) {
+        MSG("JACK: failed to activate client, continuing without audio");
+        jack_client_close(jack_client);
+        jack_client = NULL;
+        jack_port_left = NULL;
+        jack_port_right = NULL;
+        ndi_audio_sender = NULL;
+        return;
+    }
+
+    // auto-connect to crone outputs
+    if (jack_connect(jack_client, "crone:output_1", "ndi-mod:input_1") != 0) {
+        MSG("JACK: could not connect to crone:output_1 (connect manually)");
+    }
+    if (jack_connect(jack_client, "crone:output_2", "ndi-mod:input_2") != 0) {
+        MSG("JACK: could not connect to crone:output_2 (connect manually)");
+    }
+
+    MSG("JACK audio client initialized (sample rate: " << ndi_audio_frame.sample_rate << ")");
+}
+
+static void cleanup_jack() {
+    if (jack_client) {
+        jack_deactivate(jack_client);
+        jack_client_close(jack_client);
+        jack_client = NULL;
+        jack_port_left = NULL;
+        jack_port_right = NULL;
+        ndi_audio_sender = NULL;
+        MSG("JACK audio client closed");
+    }
+}
+
 int initialize_ndi() {
     if (!initialized && !failed) {
         if (!NDIlib_initialize()) {
@@ -103,12 +223,15 @@ int initialize_ndi() {
 
         cairo_surface_t* surface = cairo_get_target(ctx);
         create_sender(surface, "screen");
+
+        initialize_jack();
     }
     return 0;
 }
 
 int cleanup_ndi() {
     running = false;
+    cleanup_jack();
     if (initialized) {
         initialized = false;
 

--- a/src/ndi_mod.cpp
+++ b/src/ndi_mod.cpp
@@ -3,7 +3,6 @@
 
 #include <iostream>
 #include <map>
-#include <string.h>
 
 // lua
 #include <lauxlib.h>
@@ -14,99 +13,76 @@ extern "C" {
 // matron
 #include "lua_eval.h"
 #include "hardware/screen.h"
-// cairo
-#include <cairo.h>
 // local copies of private weaver types/methods
 #include <weaver_image.h>
 }
 
-// ndi
-#include <Processing.NDI.Lib.h>
-
-
 #define MSG(contents) \
    std::cerr << "ndi-mod: " << contents << "\n"
 
+SenderRecord::SenderRecord()
+: surface(NULL), sender(NULL), sender_name(""), buffer(NULL), buffer_size(0)
+{}
 
-class SenderRecord
+SenderRecord::SenderRecord(SenderRecord&& other) {
+    surface = other.surface;
+    sender = other.sender;
+    sender_name = other.sender_name;
+    buffer = other.buffer;
+    buffer_size = other.buffer_size;
+    frame = other.frame;
+    frame_divisor = other.frame_divisor;
+    frame_counter = other.frame_counter;
+
+    other.surface = NULL;
+    other.sender_name = "";
+    other.sender = NULL;
+    other.buffer = NULL;
+    other.buffer_size = 0;
+}
+
+SenderRecord::SenderRecord(cairo_surface_t* surface, const char* name)
+: surface(surface), sender_name(name), buffer(NULL), buffer_size(0)
 {
-public:
-    cairo_surface_t* surface;
-    NDIlib_send_instance_t sender;
-    std::string sender_name;
-    unsigned char* buffer;
-    size_t buffer_size;
-    NDIlib_video_frame_v2_t frame;
-    int frame_divisor;
-    int frame_counter;
+    NDIlib_send_create_t send_create;
+    send_create.p_ndi_name = name;
+    send_create.p_groups = NULL;
+    send_create.clock_video = false;
+    send_create.clock_audio = false;
 
-    SenderRecord()
-    : surface(NULL), sender(NULL), sender_name(""), buffer(NULL), buffer_size(0)
-    {}
-
-    SenderRecord(const SenderRecord& other) = delete;
-    SenderRecord(SenderRecord&& other) {
-        surface = other.surface;
-        sender = other.sender;
-        sender_name = other.sender_name;
-        buffer = other.buffer;
-        buffer_size = other.buffer_size;
-        frame = other.frame;
-	frame_divisor = other.frame_divisor;
-	frame_counter = other.frame_counter;
-
-        other.surface = NULL;
-        other.sender_name = "";
-        other.sender = NULL;
-        other.buffer = NULL;
-        other.buffer_size = 0;
+    sender = NDIlib_send_create(&send_create);
+    if (!sender) {
+        MSG("error creating NDI sender");
     }
 
-    SenderRecord(cairo_surface_t* surface, const char* name)
-    : surface(surface), sender_name(name), buffer(NULL), buffer_size(0)
-    {
-        NDIlib_send_create_t send_create;
-        send_create.p_ndi_name = name;
-        send_create.p_groups = NULL;
-        send_create.clock_video = false;
-        send_create.clock_audio = false;
+    frame_divisor = 1;
+    frame_counter = 0;
 
-        sender = NDIlib_send_create(&send_create);
-        if (!sender) {
-            MSG("error creating NDI sender");
-        }
+    // NDI video format: 60fps RGBA progressive (with alpha ignored.)
+    // norns cairo surfaces are CAIRO_FORMAT_ARGB32 (premultiplied ARGB.)
+    // But all four bytes are always the same, so the RGBA/ARGB mismatch
+    // doesn't matter, and we can use the surface data directly.
+    frame = {
+        .frame_rate_N = 60000,
+        .frame_rate_D = frame_divisor * 1000,
+        .FourCC = NDIlib_FourCC_type_RGBX,
+        .frame_format_type = NDIlib_frame_format_type_progressive
+    };
 
-	frame_divisor = 1;
-	frame_counter = 0;
+    cairo_surface_reference(surface); // increase refcount
+    MSG("NDI sender \"" << sender_name << "\" created");
+}
 
-        // NDI video format: 60fps RGBA progressive (with alpha ignored.)
-        // norns cairo surfaces are CAIRO_FORMAT_ARGB32 (premultiplied ARGB.)
-        // But all four bytes are always the same, so the RGBA/ARGB mismatch
-        // doesn't matter, and we can use the surface data directly.
-        frame = {
-            .frame_rate_N = 60000,
-            .frame_rate_D = frame_divisor * 1000,
-            .FourCC = NDIlib_FourCC_type_RGBX,
-            .frame_format_type = NDIlib_frame_format_type_progressive
-        };
-
-        cairo_surface_reference(surface); // increase refcount
-        MSG("NDI sender \"" << sender_name << "\" created");
+SenderRecord::~SenderRecord() {
+    if (sender != NULL) {
+        NDIlib_send_destroy(sender);
+        free(buffer);
+        MSG("NDI sender destroyed");
     }
-
-    ~SenderRecord() {
-        if (sender != NULL) {
-            NDIlib_send_destroy(sender);
-            free(buffer);
-            MSG("NDI sender destroyed");
-        }
-        if (surface != NULL) {
-            cairo_surface_destroy(surface); // decrease refcount
-        }
+    if (surface != NULL) {
+        cairo_surface_destroy(surface); // decrease refcount
     }
-
-    void send();
-};
+}
 
 std::map<cairo_surface_t*, SenderRecord> surface_sender_map;
 

--- a/src/ndi_mod.h
+++ b/src/ndi_mod.h
@@ -8,6 +8,8 @@
 #endif
 
 extern "C" {
+// cairo
+#include <cairo.h>
 
 #include "lua.h"
 #include "lauxlib.h"
@@ -15,5 +17,29 @@ extern "C" {
 NDI_MOD_API int luaopen_ndi_mod(lua_State *L);
 
 } // extern "C"
+
+// ndi
+#include <Processing.NDI.Lib.h>
+#include <cstring>
+#include <string>
+
+class SenderRecord
+{
+public:
+    cairo_surface_t* surface;
+    NDIlib_send_instance_t sender;
+    std::string sender_name;
+    unsigned char* buffer;
+    size_t buffer_size;
+    NDIlib_video_frame_v2_t frame;
+    int frame_divisor;
+    int frame_counter;
+    SenderRecord();
+    SenderRecord(const SenderRecord& other) = delete;
+    SenderRecord(SenderRecord&& other);
+    SenderRecord(cairo_surface_t* surface, const char* name);
+    ~SenderRecord();
+    void send();
+};
 
 #endif

--- a/src/ndi_mod_audio.cpp
+++ b/src/ndi_mod_audio.cpp
@@ -1,0 +1,142 @@
+#include "ndi_mod_audio.h"
+
+#include <iostream>
+#include <map>
+#include <cstring>
+
+#include <jack/jack.h>
+
+extern "C" {
+#include "hardware/screen.h"
+#include <cairo.h>
+}
+
+#include <Processing.NDI.Lib.h>
+
+#define MSG(contents) \
+   std::cerr << "ndi-mod_audio: " << contents << "\n"
+
+// from ndi_mod.cpp
+extern std::map<cairo_surface_t*, NDIlib_send_instance_t> surface_sender_map;
+extern bool running;
+
+// jack audio
+static const int NDI_JACK_MAX_FRAMES = 8192;
+static const int NDI_JACK_NUM_CHANNELS = 2;
+static jack_client_t* jack_client = NULL;
+static jack_port_t* jack_port_left = NULL;
+static jack_port_t* jack_port_right = NULL;
+static float jack_audio_buffer[NDI_JACK_NUM_CHANNELS * NDI_JACK_MAX_FRAMES];
+static NDIlib_send_instance_t ndi_audio_sender = NULL;
+static NDIlib_audio_frame_v2_t ndi_audio_frame;
+
+static int jack_process_callback(jack_nframes_t nframes, void* arg) {
+    if (!running || !ndi_audio_sender || nframes > NDI_JACK_MAX_FRAMES)
+        return 0;
+
+    float* left = (float*)jack_port_get_buffer(jack_port_left, nframes);
+    float* right = (float*)jack_port_get_buffer(jack_port_right, nframes);
+
+    // copy into planar buffer: channel 0 then channel 1
+    memcpy(jack_audio_buffer, left, nframes * sizeof(float));
+    memcpy(jack_audio_buffer + nframes, right, nframes * sizeof(float));
+
+    ndi_audio_frame.no_samples = nframes;
+    ndi_audio_frame.channel_stride_in_bytes = nframes * sizeof(float);
+    NDIlib_send_send_audio_v2(ndi_audio_sender, &ndi_audio_frame);
+
+    return 0;
+}
+
+static void jack_shutdown_callback(void* arg) {
+    MSG("JACK server shut down unexpectedly");
+    jack_client = NULL;
+    jack_port_left = NULL;
+    jack_port_right = NULL;
+    ndi_audio_sender = NULL;
+}
+
+void initialize_jack(const char* output_left, const char* output_right) {
+    // default to crone outputs if not specified
+    if (!output_left || output_left[0] == '\0') {
+        output_left = "crone:output_1";
+    }
+    if (!output_right || output_right[0] == '\0') {
+        output_right = "crone:output_2";
+    }
+
+    jack_status_t status;
+    jack_client = jack_client_open("ndi-mod", JackNoStartServer, &status);
+    if (!jack_client) {
+        MSG("JACK: could not open client (server not running?), continuing without audio");
+        return;
+    }
+
+    jack_port_left = jack_port_register(jack_client, "input_1",
+        JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+    jack_port_right = jack_port_register(jack_client, "input_2",
+        JACK_DEFAULT_AUDIO_TYPE, JackPortIsInput, 0);
+
+    if (!jack_port_left || !jack_port_right) {
+        MSG("JACK: failed to register ports, continuing without audio");
+        jack_client_close(jack_client);
+        jack_client = NULL;
+        jack_port_left = NULL;
+        jack_port_right = NULL;
+        return;
+    }
+
+    // cache the "screen" sender for audio
+    cairo_t* ctx = (cairo_t*)screen_context_get_primary();
+    if (ctx) {
+        cairo_surface_t* surface = cairo_get_target(ctx);
+        auto it = surface_sender_map.find(surface);
+        if (it != surface_sender_map.end()) {
+            ndi_audio_sender = it->second;
+        }
+    }
+
+    // pre-fill audio frame descriptor
+    memset(&ndi_audio_frame, 0, sizeof(ndi_audio_frame));
+    ndi_audio_frame.timecode = NDIlib_send_timecode_synthesize;
+    ndi_audio_frame.sample_rate = jack_get_sample_rate(jack_client);
+    ndi_audio_frame.no_channels = NDI_JACK_NUM_CHANNELS;
+    ndi_audio_frame.no_samples = 0;
+    ndi_audio_frame.p_data = jack_audio_buffer;
+    ndi_audio_frame.channel_stride_in_bytes = 0;
+
+    jack_set_process_callback(jack_client, jack_process_callback, NULL);
+    jack_on_shutdown(jack_client, jack_shutdown_callback, NULL);
+
+    if (jack_activate(jack_client)) {
+        MSG("JACK: failed to activate client, continuing without audio");
+        jack_client_close(jack_client);
+        jack_client = NULL;
+        jack_port_left = NULL;
+        jack_port_right = NULL;
+        ndi_audio_sender = NULL;
+        return;
+    }
+
+    // connect to specified outputs
+    if (jack_connect(jack_client, output_left, "ndi-mod:input_1") != 0) {
+        MSG("JACK: could not connect to " << output_left << " (connect manually)");
+    }
+    if (jack_connect(jack_client, output_right, "ndi-mod:input_2") != 0) {
+        MSG("JACK: could not connect to " << output_right << " (connect manually)");
+    }
+
+    MSG("JACK audio client initialized (sample rate: " << ndi_audio_frame.sample_rate << ")");
+}
+
+void cleanup_jack() {
+    if (jack_client) {
+        jack_deactivate(jack_client);
+        jack_client_close(jack_client);
+        jack_client = NULL;
+        jack_port_left = NULL;
+        jack_port_right = NULL;
+        ndi_audio_sender = NULL;
+        MSG("JACK audio client closed");
+    }
+}

--- a/src/ndi_mod_audio.cpp
+++ b/src/ndi_mod_audio.cpp
@@ -1,16 +1,14 @@
 #include "ndi_mod_audio.h"
+#include "ndi_mod.h"
 
 #include <iostream>
 #include <map>
 #include <vector>
-#include <cstring>
-#include <string>
 
 #include <jack/jack.h>
 
 extern "C" {
 #include "hardware/screen.h"
-#include <cairo.h>
 }
 
 #include <Processing.NDI.Lib.h>
@@ -19,7 +17,7 @@ extern "C" {
    std::cerr << "ndi-mod_audio: " << contents << "\n"
 
 // from ndi_mod.cpp
-extern std::map<cairo_surface_t*, NDIlib_send_instance_t> surface_sender_map;
+extern std::map<cairo_surface_t*, SenderRecord> surface_sender_map;
 extern bool running;
 
 // jack audio
@@ -102,7 +100,7 @@ void initialize_jack(const char** output_ports, int channel_count) {
         cairo_surface_t* surface = cairo_get_target(ctx);
         auto it = surface_sender_map.find(surface);
         if (it != surface_sender_map.end()) {
-            ndi_audio_sender = it->second;
+            ndi_audio_sender = it->second.sender;
         }
     }
 

--- a/src/ndi_mod_audio.h
+++ b/src/ndi_mod_audio.h
@@ -1,0 +1,7 @@
+#ifndef __NDI_MOD_AUDIO_H__
+#define __NDI_MOD_AUDIO_H__
+
+void initialize_jack(const char* output_left, const char* output_right);
+void cleanup_jack();
+
+#endif

--- a/src/ndi_mod_audio.h
+++ b/src/ndi_mod_audio.h
@@ -1,7 +1,7 @@
 #ifndef __NDI_MOD_AUDIO_H__
 #define __NDI_MOD_AUDIO_H__
 
-void initialize_jack(const char* output_left, const char* output_right);
+void initialize_jack(const char** output_ports, int num_channels);
 void cleanup_jack();
 
 #endif


### PR DESCRIPTION
This pull request adds support for streaming audio via JACK to the NDI module, allowing configurable multi-channel audio routing in addition to the existing video functionality. The main changes introduce new initialization and cleanup routines for audio, integrate the JACK audio system, and update the build configuration to include JACK dependencies.

**Audio Streaming Support:**

* Added new `ndi_mod_audio.cpp` and `ndi_mod_audio.h` files implementing JACK audio client integration, supporting both stereo and multi-channel audio streaming to NDI. This includes dynamic port registration, buffer management, and automatic connection to specified JACK output ports. [[1]](diffhunk://#diff-ebbf2f18fce3d2ca5ae9e9b5c17804071ac015c337c1a96616247d554524b8caR1-R161) [[2]](diffhunk://#diff-944089df790534b24e601ae06569b074a12fd59a1d5f7169e1d60608d0f832aeR1-R7)
* Exposed new Lua functions `init_audio` and `cleanup_audio` for initializing and cleaning up audio streaming, supporting both backward-compatible stereo and configurable multi-channel modes. [[1]](diffhunk://#diff-8a5c43339cfc6cbc7f466abc32acf26f41c90c6ac024e1969802bc25107dfc6bR198-R246) [[2]](diffhunk://#diff-8a5c43339cfc6cbc7f466abc32acf26f41c90c6ac024e1969802bc25107dfc6bR279-R280)
* Integrated audio initialization and cleanup into the module's startup and shutdown hooks to ensure proper resource management.

**Build System Updates:**

* Updated `CMakeLists.txt` to require and link against JACK, and to include the new audio source files and headers. [[1]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4L12-R20) [[2]](diffhunk://#diff-148715d6ea0c0ea0a346af3f6bd610d010d490eca35ac6a9b408748f7ca9e3f4R40-R45)

**Internal Refactoring:**

* Refactored state variables and function visibility to support audio integration, such as making `running` non-static and adding calls to audio cleanup in the main cleanup routine. [[1]](diffhunk://#diff-8a5c43339cfc6cbc7f466abc32acf26f41c90c6ac024e1969802bc25107dfc6bL27-R28) [[2]](diffhunk://#diff-8a5c43339cfc6cbc7f466abc32acf26f41c90c6ac024e1969802bc25107dfc6bR113) [[3]](diffhunk://#diff-8a5c43339cfc6cbc7f466abc32acf26f41c90c6ac024e1969802bc25107dfc6bR2)